### PR TITLE
Replace sudo command with become

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   apt_repository: repo='deb http://www.rabbitmq.com/debian/ testing main' state=present
 
 - name: add the verification key for the package
-  sudo: yes
+  become: yes
   shell: curl http://www.rabbitmq.com/rabbitmq-signing-key-public.asc | sudo apt-key add -
 
 - name: update repositories


### PR DESCRIPTION
Issue: [phansible/phansible/issues/273](https://github.com/phansible/phansible/issues/273)
Replace `sudo` command `become`since `sudo` will be deprecated.
